### PR TITLE
Clarify the note about when you need to use setup-bazelisk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # setup-bazelisk
 Set up your GitHub Actions workflow with a specific version of Bazelisk
 
-Note that GitHub Actions includes Bazelisk by default as of <https://github.com/actions/virtual-environments/pull/490> so this setup is not necessary unless you want to customize the Bazelisk version.
+Note that GitHub Actions includes Bazelisk by default as of <https://github.com/actions/virtual-environments/pull/490> so this setup is not necessary unless you want to customize the Bazelisk version, or are running Bazel inside a container.
 
 ![Validate 'setup-bazelisk'](https://github.com/bazelbuild/setup-bazelisk/workflows/Validate%20'setup-bazelisk'/badge.svg)
 


### PR DESCRIPTION
I'm running a Bazel action inside a container and needed to use this because
GitHub actions doesn't currently install Bazelisk there.